### PR TITLE
docs: Add x eget installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,14 @@ brew tap Jorji49/tap
 brew install streamtop
 ```
 
+### X-CMD
+
+[x-cmd](https://www.x-cmd.com/) is a modern Shell toolkit that gives AI agents and developers powerful, portable, and composable command-line capabilities.
+
+```bash
+x eget use Jorji49/streamtop
+```
+
 ### Arch (binary package)
 
 AUR submission is not listed yet. Use the packaging mirror:


### PR DESCRIPTION
Add `x eget` as an installation method for streamtop.

`x eget` allows users to install streamtop directly from its GitHub release:

```bash
x eget use Jorji49/streamtop
```